### PR TITLE
`--keep` and `cache`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - '*'
     branches:
       - main
+      - feature/cache
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
       - '*'
     branches:
       - main
-      - feature/cache
   workflow_dispatch:
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,15 @@ inputs:
       removed).
     default: ""
     required: false
+  cache:
+    description: |
+      How long should installed binaries with the same name and in the same
+      destination directory, be kept in cache before a new download will be
+      attempted. This is best expressed as a number of seconds, but also
+      supports simple human-readable periods such as 3d or 5 months. The default
+      is to keep binaries for one day.
+    default: 1d
+    required: false
 
 outputs:
   path:
@@ -68,6 +77,7 @@ runs:
           "$( ${{ github.action_path }}/${{ inputs.installer }}install.sh \
                 --destination "${{ inputs.destination }}" \
                 --bin "${{ inputs.binary }}" \
+                --keep "${{ inputs.cache }}" \
                 --verbose \
                 -- \
                   "${{ inputs.url }}" )"


### PR DESCRIPTION
This adds a `--keep` command-line options to the scripts. Binaries will be kept for this many seconds before a new download is attempted. The default for the option is `0`, meaning that downloads will always be attempted, which is backwards compatible with prior versions. The `--keep` option is relayed by a `cache` input, which defaults to `1d` (one day).

Closes #2 