### PR TITLE
add option to keep content of tar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ options are:
 * `-b`, or `--bin` or `--binary` is the name of the binary to be placed in the
   destination directory. When empty, the default, it will be the basename of the
   extraction path from the `--extract` option.
+* `-p` or `--package` is the path to a directory where to store the entire
+  content of the tar file upon installation. The directory will be created if
+  necessary. When the value of this input is not an empty string, a symbolic
+  link to the binary will be created from the 'destination' directory (with the
+  name 'binary') towards the (relative) path 'extract' under 'package'.
 * `-v`, or `--verbose` will increase verbosity.
 
 ## GitHub Action
@@ -86,6 +91,15 @@ workflow installs binaries from two GitHub projects:
 
   [jq]: https://github.com/stedolan/jq/releases
   [act]: https://github.com/nektos/act/releases
+
+If you want to make use of the `package` input in an optimal way, you should
+pertain the content of tar files over time through giving it the following
+value (see note on [caching](#caching) below).
+
+```yaml
+with:
+  package: ${{ runner.tool_cache }}/${{ github.repository }}/opt
+```
 
 ### Caching
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,9 @@ description: |
   Quickly download and install direct binaries, or binaries extracted from tar
   files. This action makes it easy to install fat binaries (statically compiled,
   such as golang binaries), picked from known github projects, e.g. kubectl, jq,
-  etc.
+  etc. The destination directory where the binaries are installed (or made
+  available from) is automatically added to the PATH, so that the binaries are
+  automatically made available to other steps.
 author: "Emmanuel Frécon <efrecon+github@gmail.com>"
 
 inputs:
@@ -44,6 +46,15 @@ inputs:
       is to keep binaries for one day.
     default: 1d
     required: false
+  package:
+    description: |
+      Path to a directory where to store the entire content of the tar file upon
+      installation. The directory will be created if necessary. When the value
+      of this input is not an empty string, a symbolic link to the binary will
+      be created from the 'destination' directory (with the name 'binary')
+      towards the (relative) path 'extract' under 'package'.
+    default: ""
+    required: false
 
 outputs:
   path:
@@ -72,6 +83,7 @@ runs:
       shell: bash
       env:
         TARINSTALL_EXTRACT: ${{ inputs.extract }}
+        TARINSTALL_PACKAGE: ${{ inputs.package }}
       run: |
         printf '::set-output name=path::%s\n' \
           "$( ${{ github.action_path }}/${{ inputs.installer }}install.sh \


### PR DESCRIPTION
This enable the storage of entire tar files, while arranging for the installed "binary" to point into the storage area. Such setups are required when the tool to install requires one or several configuration files or similar.